### PR TITLE
Killing time

### DIFF
--- a/client.go
+++ b/client.go
@@ -196,7 +196,7 @@ func DefaultScheduler(servers []string, j int) (string, int) {
 // NewClient creates a new Client with default settings.
 func NewClient() *Client {
 	return &Client{
-		HTTPClient:    cleanhttp.DefaultClient(),
+		HTTPClient:    cleanhttp.DefaultPooledClient(),
 		RetryWaitMin:  DefaultRetryWaitMin,
 		RetryWaitMax:  DefaultRetryWaitMax,
 		RetryMax:      DefaultRetryMax,

--- a/client.go
+++ b/client.go
@@ -83,7 +83,9 @@ type Request struct {
 	urls []string
 }
 
-type lenReader interface {
+// LenReader is an interface implemented by many in-memory io.Reader's. Used
+// for automatically sending the right Content-Length header when possible.
+type LenReader interface {
 	Len() int
 }
 
@@ -210,7 +212,7 @@ func NewRequest(method, durl string, body io.ReadSeeker) (*Request, error) {
 	var contentLength int64
 	raw := body
 
-	if lr, ok := raw.(lenReader); ok {
+	if lr, ok := raw.(LenReader); ok {
 		contentLength = int64(lr.Len())
 	}
 	var rBody io.ReadCloser

--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -111,7 +112,46 @@ func DefaultBackoff(min, max time.Duration, attempt int, r *http.Response) time.
 	return s
 }
 
-// DefaultRetryPolicy is the default policy for retrying http requests
+// LinearJitterBackoff provides a callback for Client.Backoff which will
+// perform linear backoff based on the attempt number and with jitter to
+// prevent a thundering herd.
+//
+// min and max here are *not* absolute values. The number to be multipled by
+// the attempt number will be chosen at random from between them, thus they are
+// bounding the jitter.
+//
+// For instance:
+// * To get strictly linear backoff of one second increasing each retry, set
+// both to one second (1s, 2s, 3s, 4s, ...)
+// * To get a small amount of jitter centered around one second increasing each
+// retry, set to around one second, such as a min of 800ms and max of 1200ms
+// (892ms, 2102ms, 2945ms, 4312ms, ...)
+// * To get extreme jitter, set to a very wide spread, such as a min of 100ms
+// and a max of 20s (15382ms, 292ms, 51321ms, 35234ms, ...)
+func LinearJitterBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	// attemptNum always starts at zero but we want to start at 1 for multiplication
+	attemptNum++
+
+	if max <= min {
+		// Unclear what to do here, or they are the same, so return min *
+		// attemptNum
+		return min * time.Duration(attemptNum)
+	}
+
+	// Seed rand; doing this every time is fine
+	rand := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+
+	// Pick a random number that lies somewhere between the min and max and
+	// multiply by the attemptNum. attemptNum starts at zero so we always
+	// increment here. We first get a random percentage, then apply that to the
+	// difference between min and max, and add to min.
+	jitter := rand.Float64() * float64(max-min)
+	jitterMin := int64(jitter) + int64(min)
+	return time.Duration(jitterMin * int64(attemptNum))
+}
+
+// DefaultRetryPolicy provides a default callback for Client.CheckRetry, which
+// will retry on connection errors and server errors.
 func DefaultRetryPolicy(ctx context.Context, r *http.Response, err error) (bool, error) {
 	if ctx.Err() != nil {
 		return false, ctx.Err()

--- a/client_test.go
+++ b/client_test.go
@@ -43,9 +43,9 @@ func TestRequest(t *testing.T) {
 	}
 
 	// Sets the Content-Length automatically for LenReaders
-	// if req.ContentLength != 2 {
-	// 	t.Fatalf("bad ContentLength: %d", req.ContentLength)
-	// }
+	if req.ContentLength != 2 {
+		t.Fatalf("bad ContentLength: %d", req.ContentLength)
+	}
 }
 
 // Since normal ways we would generate a Reader have special cases, use a


### PR DESCRIPTION
This PR updated several comments to make docs clearer (and following most 'upstream' docs since I'm really bad at it).
Also it adds a Jittered backoff function (also upstream)
Exports LenReader()
Changes default http client